### PR TITLE
fix: correct dedup key and add state filtering to prevent merged PR false positives

### DIFF
--- a/gh-monday
+++ b/gh-monday
@@ -391,7 +391,7 @@ fetch_github_items() {
 
     # Process issues - filter by activity window
     printf '%s' "$issues_involving" | jq -r --arg me "$MY_USERNAME" --argjson cutoff "$EVENT_CUTOFF_EPOCH" '
-        .[] | select(.state | ascii_downcase == "open") | select(.isPullRequest == false) | select((.updatedAt | fromdateiso8601) >= $cutoff) | [
+        .[] | select(.state | ascii_downcase == "open") | select(.isPullRequest != true) | select((.updatedAt | fromdateiso8601) >= $cutoff) | [
             "issue",
             .repository.nameWithOwner,
             .number,


### PR DESCRIPTION
## Summary

- Merged/closed PRs were appearing in the ACTION NEEDED section as false positives
- Two root causes fixed:
  1. **Deduplication key was `type|repo|number`** — `gh search issues --involves=@me` returns PRs too (GitHub treats PRs as issues at the API level). The same PR could survive dedup as both `type=pr` and `type=issue`, appearing twice with potentially conflicting "waiting on me" status. Changed key to `repo|number` so they collapse to one entry, keeping the highest-priority role.
  2. **No client-side state filter** — GitHub's search index has a brief lag; a just-merged PR can still appear in `--state=open` results. Added `state` to all `--json` fields and `select(.state == "open")` to all four jq pipelines as a defensive filter. The issues search also gets `select(.isPullRequest == false)` to exclude PRs already covered by the dedicated PR searches.

## Test plan

- [ ] Run `gh monday` after merging a PR — it should not appear in ACTION NEEDED
- [ ] Verify a PR that appears in both author and involves searches appears only once
- [ ] Confirm real open PRs/issues still appear correctly in both sections
- [ ] Check that the `isPullRequest` field is available in `gh search issues --json` output (if not, the `|| echo "[]"` fallback keeps behavior safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)